### PR TITLE
Also request `https://www.googleapis.com/auth/userinfo.email` scope

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,13 @@ func main() {
 	}
 
 	// get a token
-	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	scopes := []string{
+		// Base scope for GCP auth
+		"https://www.googleapis.com/auth/cloud-platform",
+		// Needed in order to use service account emails instead of unique IDs in K8S RBAC.
+		"https://www.googleapis.com/auth/userinfo.email",
+	}
+	ts, err := google.DefaultTokenSource(ctx, scopes...)
 	if err != nil {
 		log.Fatalf("google.DefaultTokenSource: %v", err)
 	}


### PR DESCRIPTION
The gcloud cred helper [requests these scopes](https://github.com/kubernetes/cloud-provider-gcp/blob/c19c59784df56ac2d02c48ee31475afd771200e0/cmd/gke-gcloud-auth-plugin/default_credentials_token_provider.go#L17-L19) when obtaining a token. Without this scope, service accounts authenticate to GKE as their unique ID, which means the RBAC policies must be written the same way. This is inconvenient when authoring policies since it's hard to reason about which authentication flows will use the email vs unique ID.