### PR TITLE
Group all Dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,12 +10,9 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
     groups:
-      all:
+      gomod:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -24,7 +21,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
     groups:
-      all:
-        update-types:
-          - "minor"
-          - "patch"
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Configure Dependabot so all dependency updates are grouped into a single PR per ecosystem (`gomod` and `github-actions`), instead of one PR per dependency.
- Previously each group only matched `minor`/`patch` updates, so major version bumps (e.g. the recent `google-github-actions/auth` 2.x → 3.x) still arrived as standalone PRs. This drops the `update-types` restriction and adds the missing `patterns: ["*"]` to the `github-actions` group.

## Behavior after this change
- One grouped `gomod` PR covering all Go module updates.
- One grouped `github-actions` PR covering all Action updates.
- Applies to all update types, including major version bumps.

## Test plan
- [ ] Dependabot validates `.github/dependabot.yaml` (no config errors on the Dependabot dashboard).
- [ ] Next scheduled run produces grouped PRs rather than per-dependency PRs.

Made with [Cursor](https://cursor.com)