### PR TITLE
Add --alias flag to customize kubeconfig context name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,10 @@ inputs:
   cluster:
     description: "Name of the cluster"
     required: true
+  alias:
+    description: "Alias name for the kubeconfig context (defaults to gke_{project}_{location}_{cluster})"
+    required: false
+    default: ""
   registry_location:
     description: "Region or multi-region of the Artifact Registry instance"
     required: false
@@ -53,6 +57,13 @@ runs:
         gke-auth --location=${{ inputs.registry_location }} --configure-docker
       fi
 
-      gke-auth --project=${{ inputs.project }} \
-          --location=${{ inputs.location }} \
-          --cluster=${{ inputs.cluster }}
+      args=(
+        --project=${{ inputs.project }}
+        --location=${{ inputs.location }}
+        --cluster=${{ inputs.cluster }}
+      )
+      if [[ "${{ inputs.alias }}" != "" ]]; then
+        args+=(--alias=${{ inputs.alias }})
+      fi
+
+      gke-auth "${args[@]}"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	project     = flag.String("project", "", "Name of the project")
 	location    = flag.String("location", "", "Location of the cluster")
 	clusterName = flag.String("cluster", "", "Name of the cluster")
+	alias       = flag.String("alias", "", "Alias name for the kubeconfig context (defaults to gke_{project}_{location}_{cluster})")
 
 	get             = flag.Bool("get", false, "If true, print auth information")
 	clear           = flag.Bool("clear", false, "If true, clear auth for this cluster")
@@ -163,6 +164,9 @@ func main() {
 
 	// get kubeconfig location
 	key := fmt.Sprintf("gke_%s_%s_%s", *project, *location, *clusterName)
+	if *alias != "" {
+		key = *alias
+	}
 	kcfgPath := clientcmd.RecommendedHomeFile
 	if auth := cfg.AuthInfos[key]; auth != nil && auth.LocationOfOrigin != "" {
 		kcfgPath = auth.LocationOfOrigin


### PR DESCRIPTION
### Summary

The default kubeconfig context name generated by gke-auth follows the pattern `gke_{project}_{location}_{cluster}`, which is verbose and inconvenient to type or reference in scripts.

This PR adds an `--alias` flag so users can specify a custom name for the kubeconfig context, cluster, and user entries.

### Usage

```bash
gke-auth --project=my-project --location=us-central1 --cluster=prod-cluster --alias=prod
kubectl config use-context prod
```